### PR TITLE
fix: unfiltered infima shown per edition

### DIFF
--- a/app/home/models.py
+++ b/app/home/models.py
@@ -153,8 +153,11 @@ class Infimum(CRUDMixin, db.Model):
         return filtered_results
 
     @classmethod
-    def get_infima_with_supremum_id(cls, id):
-        return cls.query.filter_by(supremum_id=id).all()
+    def get_infima_with_supremum_id(cls, id, filter_rejected=None):
+        query = cls.query.filter_by(supremum_id=id)
+        if filter_rejected is not None:
+            query = query.filter_by(rejected=filter_rejected)
+        return query.all()
 
     @classmethod
     def get_random_infimum(cls, depth=0):

--- a/app/home/routes.py
+++ b/app/home/routes.py
@@ -81,7 +81,7 @@ def infima_for_edition(volume_nr, edition_nr):
         return code_page(404, f'Supremum {volume_nr}.{edition_nr} does not (yet) exist.')
 
     # Retrieve infima
-    infima = Infimum.get_infima_with_supremum_id(supremum.id)
+    infima = Infimum.get_infima_with_supremum_id(supremum.id, False)
 
     return render('infima_edition.html', supremum=supremum,
                   infima=infima, user=current_user), 200


### PR DESCRIPTION
Adds an optional filter to `get_infima_with_supremum_id` to allow filtering on the rejected state of the infima for a specific edition.

Fixes GH-16.

Co-Authored-By: @rinkp